### PR TITLE
add covering indexes for API pagination

### DIFF
--- a/cmd/load.go
+++ b/cmd/load.go
@@ -176,18 +176,26 @@ func createSchema(ctx context.Context, db *sql.DB) error {
 func createIndexes(ctx context.Context, db *sql.DB) error {
 	logger.Info("creating indexes - this may take several minutes...")
 	stmts := []string{
-		// Índices para estabelecimentos (consultas mais comuns)
+		// Índices simples — usados por lookups pontuais e filtros isolados.
 		`CREATE INDEX IF NOT EXISTS idx_estab_cnpj ON estabelecimentos(cnpj_basico);`,
 		`CREATE INDEX IF NOT EXISTS idx_estab_mun_uf ON estabelecimentos(municipio, uf);`,
 		`CREATE INDEX IF NOT EXISTS idx_estab_uf ON estabelecimentos(uf);`,
 		`CREATE INDEX IF NOT EXISTS idx_estab_cnae ON estabelecimentos(cnae_fiscal_principal);`,
 		`CREATE INDEX IF NOT EXISTS idx_estab_situacao ON estabelecimentos(situacao_cadastral);`,
 		`CREATE INDEX IF NOT EXISTS idx_estab_cep ON estabelecimentos(cep);`,
-
-		// Índice para matriz/filial (útil para agregações)
 		`CREATE INDEX IF NOT EXISTS idx_estab_matriz_filial ON estabelecimentos(identificador_matriz_filial);`,
 
-		// Índices para socios (consultas por empresa e por CPF)
+		// Covering indexes para listagem paginada da API (/api/v1/companies).
+		// A API filtra por uma coluna e ordena pelo PK composto para cursor
+		// pagination; sem combinar filtro + PK no mesmo índice o SQLite cai
+		// num sort em temp B-tree que estoura o timeout HTTP em filtros
+		// amplos (ex.: uf=SP ≈ 20 M linhas).
+		`CREATE INDEX IF NOT EXISTS idx_estab_uf_pk ON estabelecimentos(uf, cnpj_basico, cnpj_ordem, cnpj_dv);`,
+		`CREATE INDEX IF NOT EXISTS idx_estab_mun_pk ON estabelecimentos(municipio, cnpj_basico, cnpj_ordem, cnpj_dv);`,
+		`CREATE INDEX IF NOT EXISTS idx_estab_cnae_pk ON estabelecimentos(cnae_fiscal_principal, cnpj_basico, cnpj_ordem, cnpj_dv);`,
+		`CREATE INDEX IF NOT EXISTS idx_estab_situacao_pk ON estabelecimentos(situacao_cadastral, cnpj_basico, cnpj_ordem, cnpj_dv);`,
+
+		// Sócios — lookups por empresa e busca reversa por CPF ofuscado.
 		`CREATE INDEX IF NOT EXISTS idx_socios_cnpj ON socios(cnpj_basico);`,
 		`CREATE INDEX IF NOT EXISTS idx_socios_cpf ON socios(cnpj_cpf_socio);`,
 	}

--- a/schema.sql
+++ b/schema.sql
@@ -123,16 +123,23 @@ CREATE TABLE IF NOT EXISTS motivos (
 -- INDICES
 -- =============================================================================
 
--- Indices para estabelecimentos (consultas mais comuns)
+-- Indices simples - lookups pontuais e filtros isolados
 CREATE INDEX IF NOT EXISTS idx_estab_cnpj ON estabelecimentos(cnpj_basico);
 CREATE INDEX IF NOT EXISTS idx_estab_mun_uf ON estabelecimentos(municipio, uf);
 CREATE INDEX IF NOT EXISTS idx_estab_uf ON estabelecimentos(uf);
 CREATE INDEX IF NOT EXISTS idx_estab_cnae ON estabelecimentos(cnae_fiscal_principal);
 CREATE INDEX IF NOT EXISTS idx_estab_situacao ON estabelecimentos(situacao_cadastral);
 CREATE INDEX IF NOT EXISTS idx_estab_cep ON estabelecimentos(cep);
-
--- Indice para matriz/filial (util para agregacoes)
 CREATE INDEX IF NOT EXISTS idx_estab_matriz_filial ON estabelecimentos(identificador_matriz_filial);
+
+-- Covering indexes para a listagem paginada da API (/api/v1/companies).
+-- A API filtra por uma coluna e ordena pelo PK composto; sem combinar
+-- filtro + PK o SQLite cai num sort em temp B-tree que estoura o timeout
+-- HTTP em filtros amplos (uf=SP -> ~20M linhas).
+CREATE INDEX IF NOT EXISTS idx_estab_uf_pk       ON estabelecimentos(uf, cnpj_basico, cnpj_ordem, cnpj_dv);
+CREATE INDEX IF NOT EXISTS idx_estab_mun_pk      ON estabelecimentos(municipio, cnpj_basico, cnpj_ordem, cnpj_dv);
+CREATE INDEX IF NOT EXISTS idx_estab_cnae_pk     ON estabelecimentos(cnae_fiscal_principal, cnpj_basico, cnpj_ordem, cnpj_dv);
+CREATE INDEX IF NOT EXISTS idx_estab_situacao_pk ON estabelecimentos(situacao_cadastral, cnpj_basico, cnpj_ordem, cnpj_dv);
 
 -- Indices para socios (consultas por empresa e por CPF)
 CREATE INDEX IF NOT EXISTS idx_socios_cnpj ON socios(cnpj_basico);


### PR DESCRIPTION
## Summary

The \`brazildata/api\` listing endpoint (\`GET /api/v1/companies\`) filters on one column (uf, municipio, cnae_fiscal_principal or situacao_cadastral) and paginates by the composite PK \`(cnpj_basico, cnpj_ordem, cnpj_dv)\`. Without an index that combines the filter with the PK, SQLite materialises millions of matching rows into a temp B-tree just to sort before applying LIMIT — a broad filter like \`uf=SP\` (~20 M rows) hits the API's 10 s request deadline in production.

\`EXPLAIN QUERY PLAN\` on the current \`cnpj.sqlite\` confirmed it:

\`\`\`
SEARCH e USING INDEX idx_estab_uf (uf=?)
SEARCH em USING INDEX sqlite_autoindex_empresas_1 (cnpj_basico=?)
USE TEMP B-TREE FOR ORDER BY       ← the entire budget goes here
\`\`\`

Add four covering indexes to \`createIndexes()\` so the planner walks the index in PK order and stops at LIMIT — no sort:

- \`idx_estab_uf_pk (uf, cnpj_basico, cnpj_ordem, cnpj_dv)\`
- \`idx_estab_mun_pk (municipio, cnpj_basico, cnpj_ordem, cnpj_dv)\`
- \`idx_estab_cnae_pk (cnae_fiscal_principal, cnpj_basico, cnpj_ordem, cnpj_dv)\`
- \`idx_estab_situacao_pk (situacao_cadastral, cnpj_basico, cnpj_ordem, cnpj_dv)\`

Each adds ~2 GB to the final DB and a few minutes of build time on a 67 M-row base. Existing single-column indexes are kept so lookups with \`WHERE uf=?\` without ORDER BY still have the leaner option.

\`schema.sql\` is the human reference and was kept in sync.

## Test plan

- [x] \`go build ./...\` and \`go vet ./...\` pass.
- [ ] Run a full ingest (\`bcd load\`) and confirm the four indexes land in \`sqlite_master\`.
- [ ] On the API side, \`curl '.../api/v1/companies?uf=SP&limit=3'\` returns in under a second; \`EXPLAIN QUERY PLAN\` no longer prints \`USE TEMP B-TREE FOR ORDER BY\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)