### PR TITLE
create FTS5 virtual tables during bcd load

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,15 @@ go build -o bcd
 
 # 3a) Se encontrar erro de memória, use --skip-vacuum
 ./bcd load     --ym 2025-01 --workdir /tmp/cnpj_rf --out ./cnpj.sqlite --skip-vacuum
+
+# 3b) Para pular a criação das FTS5 (busca textual), --skip-fts
+#     Ganha ~5–10 min + ~2–3 GB; em contrapartida /api/v1/companies?q= fica lento.
+./bcd load     --ym 2025-01 --workdir /tmp/cnpj_rf --out ./cnpj.sqlite --skip-fts
 ```
+
+> `bcd load` já cria as virtual tables `empresas_fts` e `estabelecimentos_fts`
+> consumidas pela [API](https://github.com/brazildata/api) em `/api/v1/companies?q=`.
+> Tokenizer `unicode61 remove_diacritics 2` (busca sem acento).
 
 ### Requisitos de Memória
 

--- a/cmd/load.go
+++ b/cmd/load.go
@@ -206,6 +206,13 @@ func createIndexes(ctx context.Context, db *sql.DB) error {
 		}
 	}
 
+	// FTS5 virtual tables para busca textual em razão social / nome fantasia.
+	// Roda antes de ANALYZE/VACUUM para aproveitar journal_mode=MEMORY do bulk
+	// load; o VACUUM que vem depois compacta também as shadow tables do FTS.
+	if err := createFTSTables(ctx, db); err != nil {
+		return err
+	}
+
 	// ANALYZE atualiza estatísticas do query planner
 	logger.Info("analyzing tables for query optimization...")
 	if err := exec(ctx, db, `ANALYZE;`); err != nil {
@@ -253,6 +260,54 @@ func createIndexes(ctx context.Context, db *sql.DB) error {
 
 	logger.Info("indexes and optimizations completed")
 	logger.Info("database is ready for high-performance reads")
+	return nil
+}
+
+// createFTSTables cria as virtual tables FTS5 (empresas_fts e
+// estabelecimentos_fts) consumidas pela API em /api/v1/companies?q=<termo>.
+// Tokenizer unicode61 + remove_diacritics faz "sao paulo" casar com
+// "São Paulo". Drop-and-recreate é intencional: a RFB é batch mensal,
+// triggers de sync incremental só atrasariam o bulk load sem benefício real.
+func createFTSTables(ctx context.Context, db *sql.DB) error {
+	if flagSkipFTS {
+		logger.Info("skipping FTS5 virtual tables (--skip-fts)")
+		return nil
+	}
+	logger.Info("creating FTS5 virtual tables - this may take a few minutes...")
+
+	steps := []struct{ label, sql string }{
+		{"drop empresas_fts", `DROP TABLE IF EXISTS empresas_fts;`},
+		{"drop estabelecimentos_fts", `DROP TABLE IF EXISTS estabelecimentos_fts;`},
+		{"create empresas_fts", `CREATE VIRTUAL TABLE empresas_fts USING fts5(
+			cnpj_basico UNINDEXED,
+			razao_social,
+			tokenize = 'unicode61 remove_diacritics 2'
+		);`},
+		{"create estabelecimentos_fts", `CREATE VIRTUAL TABLE estabelecimentos_fts USING fts5(
+			cnpj_basico UNINDEXED,
+			cnpj_ordem UNINDEXED,
+			cnpj_dv UNINDEXED,
+			nome_fantasia,
+			tokenize = 'unicode61 remove_diacritics 2'
+		);`},
+		{"populate empresas_fts", `INSERT INTO empresas_fts(cnpj_basico, razao_social)
+			SELECT cnpj_basico, razao_social
+			  FROM empresas
+			 WHERE razao_social IS NOT NULL AND razao_social <> '';`},
+		{"populate estabelecimentos_fts", `INSERT INTO estabelecimentos_fts(cnpj_basico, cnpj_ordem, cnpj_dv, nome_fantasia)
+			SELECT cnpj_basico, cnpj_ordem, cnpj_dv, nome_fantasia
+			  FROM estabelecimentos
+			 WHERE nome_fantasia IS NOT NULL AND nome_fantasia <> '';`},
+		{"optimize empresas_fts", `INSERT INTO empresas_fts(empresas_fts) VALUES('optimize');`},
+		{"optimize estabelecimentos_fts", `INSERT INTO estabelecimentos_fts(estabelecimentos_fts) VALUES('optimize');`},
+	}
+	for _, s := range steps {
+		logger.Info("fts step", slog.String("step", s.label))
+		if err := exec(ctx, db, s.sql); err != nil {
+			return fmt.Errorf("fts %s: %w", s.label, err)
+		}
+	}
+	logger.Info("fts5 tables ready")
 	return nil
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ var (
 	flagWorkdir    string
 	flagOutDB      string
 	flagSkipVacuum bool
+	flagSkipFTS    bool
 	flagShareToken string
 	flagMode       string // "zip" or "tar"
 	logger         *slog.Logger
@@ -53,6 +54,7 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&flagWorkdir, "workdir", "", "diretório de trabalho (default /tmp/cnpj_rf)")
 	RootCmd.PersistentFlags().StringVar(&flagOutDB, "out", "", "arquivo SQLite de saída (default ./cnpj.sqlite)")
 	RootCmd.PersistentFlags().BoolVar(&flagSkipVacuum, "skip-vacuum", false, "pula a operação VACUUM (útil em ambientes com pouca memória)")
+	RootCmd.PersistentFlags().BoolVar(&flagSkipFTS, "skip-fts", false, "pula a criação das virtual tables FTS5 (empresas_fts, estabelecimentos_fts)")
 	RootCmd.PersistentFlags().StringVar(&flagShareToken, "share-token", "YggdBLfdninEJX9", "Nextcloud share token")
 	RootCmd.PersistentFlags().StringVar(&flagMode, "mode", "zip", "modo de download/extração: 'zip' ou 'tar'")
 }

--- a/schema.sql
+++ b/schema.sql
@@ -144,3 +144,23 @@ CREATE INDEX IF NOT EXISTS idx_estab_situacao_pk ON estabelecimentos(situacao_ca
 -- Indices para socios (consultas por empresa e por CPF)
 CREATE INDEX IF NOT EXISTS idx_socios_cnpj ON socios(cnpj_basico);
 CREATE INDEX IF NOT EXISTS idx_socios_cpf ON socios(cnpj_cpf_socio);
+
+-- =============================================================================
+-- FTS5 (virtual tables) — criadas automaticamente pelo `bcd load`.
+-- Nao use este arquivo para recria-las manualmente; rode `bcd load` (ou o
+-- script scripts/setup_fts.sql do repo brazildata/api em bancos legados).
+--
+-- Tokenizer unicode61 + remove_diacritics faz "sao paulo" casar com "Sao Paulo".
+-- =============================================================================
+-- CREATE VIRTUAL TABLE empresas_fts USING fts5(
+--     cnpj_basico UNINDEXED,
+--     razao_social,
+--     tokenize = 'unicode61 remove_diacritics 2'
+-- );
+-- CREATE VIRTUAL TABLE estabelecimentos_fts USING fts5(
+--     cnpj_basico UNINDEXED,
+--     cnpj_ordem UNINDEXED,
+--     cnpj_dv UNINDEXED,
+--     nome_fantasia,
+--     tokenize = 'unicode61 remove_diacritics 2'
+-- );


### PR DESCRIPTION
## Summary

\`GET /api/v1/companies?q=<termo>\` in [brazildata/api](https://github.com/brazildata/api) expects the virtual tables \`empresas_fts\` and \`estabelecimentos_fts\` (tokenizer \`unicode61 remove_diacritics 2\` — so \"sao paulo\" matches \"São Paulo\"). When they are missing the handler falls back to \`LIKE '%q%'\` on a 67 M-row base, which only avoids timeouts because of the cursor \`LIMIT\` early-exit.

Until now these tables had to be created by hand with \`brazildata/api/scripts/setup_fts.sql\` after each ingest — an easy step to forget. This PR runs that work automatically during \`bcd load\`:

- \`createFTSTables()\` helper in \`cmd/load.go\` drops, recreates and populates both FTS tables, then \`INSERT ... VALUES('optimize')\` on each. Called from inside \`createIndexes()\` **before** \`ANALYZE\` so the bulk inserts ride the fast \`journal_mode=MEMORY\` + \`synchronous=OFF\` pragmas still in effect, and the later \`VACUUM\` compacts the FTS shadow tables with everything else.
- New \`--skip-fts\` flag (mirroring \`--skip-vacuum\`) for ingests where you want to trade a few minutes and ~2–3 GB for missing text search.
- \`schema.sql\` gets a commented FTS block pointing readers back at the CLI.
- \`README.md\` mentions \`--skip-fts\` alongside \`--skip-vacuum\`.

## Test plan

- [x] \`go build ./...\` and \`go vet ./...\`.
- [ ] Ingest a small subset, confirm \`sqlite_master\` lists both FTS tables, and \`SELECT cnpj_basico FROM empresas_fts WHERE empresas_fts MATCH 'petrobras' LIMIT 3\` returns rows.
- [ ] Ingest with \`--skip-fts\` and confirm the tables are absent.
- [ ] Next production ingest: deploy the new DB to OCI and hit \`https://oci.dadosbrasil.net/api/v1/companies?q=petrobras&limit=5\`; journal logs should show \`fts availability available=true\` and latency stays under 100 ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)